### PR TITLE
adds distribution management and renames artifact

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Lookup Account Authentication Action Plugin
 =============================================
 
-.. image:: https://img.shields.io/badge/quality-demo-red
+.. image:: https://img.shields.io/badge/quality-production-green
    :target: https://curity.io/resources/code-examples/status/
    :alt: Quality
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.curity.identityserver.plugins.action.lookupaccount</groupId>
-    <artifactId>lookup-account-action</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <groupId>io.curity.identityserver.plugin</groupId>
+    <artifactId>identityserver.plugins.authenticationactions.lookup-account</artifactId>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <name>Curity LookupAccount Authentication Action</name>
@@ -78,4 +78,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>customer-release-repo</id>
+            <name>Curity Nexus Release Repository</name>
+            <url>https://nexus.curityio.net/repository/customer-release-repo/</url>
+        </repository>
+        <snapshotRepository>
+            <id>customer-snapshot-repo</id>
+            <name>Curity Nexus Snapshot Repository</name>
+            <url>https://nexus.curityio.net/repository/customer-snapshot-repo/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>


### PR DESCRIPTION
This PR:
- Renames the plugin so that it uses a `groupId` and `artifactId` more similar to the other plugins that are bundled in identity server.
- Sets the version to `1.0.0` (without `SNAPSHOT`)
- Adds `distributionManagement` to `pom.xml`.
- Updates the project badges to reflect the production quality and the fact that it is bundled in the product.